### PR TITLE
Use mojo implementation by default

### DIFF
--- a/lib/src/firebase.dart
+++ b/lib/src/firebase.dart
@@ -9,8 +9,8 @@ import 'transaction_result.dart';
 
 // Once conditional imports work, use dart:ui to determine whether to import
 // the mojo or js implementations
-import 'js/firebase.dart';
-// import 'mojo/firebase.dart';
+// import 'js/firebase.dart';
+import 'mojo/firebase.dart';
 
 /**
  * A Firebase represents a particular location in your Firebase and can be used


### PR DESCRIPTION
For our fork at least, mojo should be the default implementation of firebase-dart.

Once conditional imports are a thing, we can merge the repos and select at compile time